### PR TITLE
Explicitly set source encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,10 @@
     <version>0.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Maven build outputs warnings when building due to unset character encoding in the compiler settings. This results in platform specific encodings to be set. This PR silences these warnings.